### PR TITLE
Fix for 'designation' is not a key in all fields.

### DIFF
--- a/pyonepassword/pyonepassword.py
+++ b/pyonepassword/pyonepassword.py
@@ -117,6 +117,8 @@ class OP:
         fields = details['fields']
         value = None
         for field in fields:
+            if 'designation' not in field.keys():
+                continue
             if field['designation'] == field_designation:
                 value = field['value']
 


### PR DESCRIPTION
I got hit by the following:

    op.lookup('xyz')
    Traceback (most recent call last):
      File "<input>", line 1, in <module>
      File ".../pyonepassword/pyonepassword.py", line 122, in lookup
        if field['designation'] == field_designation:
    KeyError: 'designation'

That `field` object looked like this:

```
pprint(field)
{'id': 'cookie-button;opid=__0', 'type': 'I', 'value': 'Registrieren'}
```

This aims to prevent this error to happen.