### PR TITLE
Implement MFA support via the pexpect library

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,16 @@ python3 -m pip install pyonepassword
 
 ## Example usage
 
-> Note: It is recommended to perform initial sign-in manually on the command line before using `pyonepassword`. Initial sign-in is supported but deprecated. Multi-factor-authenticaiton is not supported.
+> Note: It is recommended to perform initial sign-in manually on the command line before using `pyonepassword`. 
+> MFA is supported *on Unix systems*, but requires some configuration in the client application (e.g. storing a TOTP 
+> shared secret in order to automatically generate an MFA token) depending on the type of MFA device. MFA also utilizes 
+> unix ptys via the `pexpect` library, and as such is less stable than standard POSIX pipes.  
 
 ### Subsequent sign-in and item retrieval
 
 Below is an example demonstrating:
 
-- Subsequant sign-in
+- Subsequent sign-in
 - Specifying a default vault for queries
 - Retrieving an item from 1Password by name or by UUID
 - Overriding the default vault to retrieve a subsequent item from 1Password

--- a/pyonepassword/py_op_exceptions.py
+++ b/pyonepassword/py_op_exceptions.py
@@ -87,6 +87,10 @@ class OPGetGroupException(OPCmdFailedException):
     MSG = "1Password 'get group' failed."
 
 
+class OPListEventsException(OPCmdFailedException):
+    MSG = "1Password 'list events' failed."
+
+
 class OPInvalidDocumentException(_OPAbstractException):
 
     def __init__(self, msg):

--- a/pyonepassword/pyonepassword.py
+++ b/pyonepassword/pyonepassword.py
@@ -18,7 +18,8 @@ from .py_op_exceptions import (
     OPForgetException,
     OPGetUserException,
     OPGetVaultException,
-    OPGetGroupException
+    OPGetGroupException,
+    OPListEventsException
 )
 
 
@@ -135,7 +136,7 @@ class OP(_OPCLIExecute):
             output = self._run(
                 lookup_argv, capture_stdout=True, decode="utf-8")
         except OPCmdFailedException as ocfe:
-            raise OPGetItemException.from_opexception(ocfe) from ocfe
+            raise OPListEventsException.from_opexception(ocfe) from ocfe
 
         item_dict = json.loads(output)
         return item_dict

--- a/pyonepassword/pyonepassword.py
+++ b/pyonepassword/pyonepassword.py
@@ -28,7 +28,7 @@ class OP(_OPCLIExecute):
     """
 
     def __init__(self, vault=None, account_shorthand=None, signin_address=None, email_address=None,
-                 secret_key=None, password=None, logger=None, op_path='op'):
+                 secret_key=None, password=None, mfa_code=None, logger=None, op_path='op'):
         """
         Create an OP object. The 1Password sign-in happens during object instantiation.
         If 'password' is not provided, the 'op' command will prompt on the console for a password.
@@ -48,6 +48,7 @@ class OP(_OPCLIExecute):
             - 'email_address': Email of the address for the user of the account
             - 'secret_key': Secret key for the account
             - 'password': The user's master password
+            - 'mfa_code': 6-digit MFA code
             - 'logger': A logging object. If not provided a basic logger is created and used.
             - 'op_path': optional path to the `op` command, if it's not at the default location
 
@@ -60,6 +61,7 @@ class OP(_OPCLIExecute):
                          email_address=email_address,
                          secret_key=secret_key,
                          password=password,
+                         mfa_code=mfa_code,
                          logger=logger,
                          op_path=op_path)
         self.vault = vault

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+pexpect


### PR DESCRIPTION
This is a cleaner implementation of MFA support using the pty concept as discussed in #9. This implementation uses the [pexpect](https://github.com/pexpect/pexpect) library, which utilizes Unix PTYs in order to interact with the child process. With the interface provided by this library, I was able to fairly cleanly interact with the MFA prompt, handle errors and return a token -- all without the funky timing issues of my own proof of concept.

The downside to this implementation is that it is _not_ cross-platform; [pexpect does support Windows](https://pexpect.readthedocs.io/en/stable/overview.html#pexpect-on-windows), but requires a few changes when it comes to spawning a child on Windows. As I do not have a Windows system to test on, I simply made any signin that doesn't require MFA use the standard POSIX `_run_signin` method. Windows support could be added relatively easily using just pexpect, or there is a drop-in replacement designed for Windows called [wexpect](https://wexpect.readthedocs.io/en/latest/index.html).

With this PR, there should be no breaking changes for current users; however, Unix users will be able to add an additional `mfa_code` parameter and use MFA-enabled accounts.