### PR TITLE
Added support for TOTP code retrieval using 'op get totp' cli command

### DIFF
--- a/pyonepassword/_py_op_cli.py
+++ b/pyonepassword/_py_op_cli.py
@@ -357,6 +357,16 @@ class _OPArgv(list):
         return argv
 
     @classmethod
+    def get_totp_argv(cls, op_exe, item_name_or_uuid, vault=None):
+        sub_cmd_args = []
+        if vault:
+            sub_cmd_args.extend(["--vault", vault])
+
+        argv = cls.get_generic_argv(
+            op_exe, "totp", item_name_or_uuid, sub_cmd_args)
+        return argv
+
+    @classmethod
     def get_document_argv(cls, op_exe, document_name_or_uuid, vault=None):
         sub_cmd_args = []
         if vault:

--- a/pyonepassword/_py_op_commands.py
+++ b/pyonepassword/_py_op_commands.py
@@ -47,6 +47,13 @@ class _OPCommandInterface(_OPCLIExecute):
             self.op_path, item_name_or_uuid, vault=vault_arg, fields=fields)
         return lookup_argv
 
+    def _get_totp_argv(self, item_name_or_uuid, vault=None):
+        vault_arg = vault if vault else self.vault
+
+        lookup_argv = _OPArgv.get_totp_argv(
+            self.op_path, item_name_or_uuid, vault=vault_arg)
+        return lookup_argv
+
     def _get_document_argv(self, document_name_or_uuid: str, vault: str = None):
         vault_arg = vault if vault else self.vault
 
@@ -81,6 +88,17 @@ class _OPCommandInterface(_OPCLIExecute):
         try:
             output = self._run(
                 get_item_argv, capture_stdout=True, decode=decode)
+        except OPCmdFailedException as ocfe:
+            raise OPGetItemException.from_opexception(ocfe) from ocfe
+
+        return output
+
+    def _get_totp(self, item_name_or_uuid, vault=None, decode="utf-8"):
+        get_totp_argv = self._get_totp_argv(
+            item_name_or_uuid, vault=vault)
+        try:
+            output = self._run(
+                get_totp_argv, capture_stdout=True, decode=decode)
         except OPCmdFailedException as ocfe:
             raise OPGetItemException.from_opexception(ocfe) from ocfe
 

--- a/pyonepassword/pyonepassword.py
+++ b/pyonepassword/pyonepassword.py
@@ -74,6 +74,10 @@ class _OPPrivate(_OPCommandInterface):
         op_item = OPItemFactory.op_item_from_json(output)
         return op_item
 
+    def get_totp(self, item_name_or_uuid, vault=None):
+        output = super()._get_totp(item_name_or_uuid, vault=vault, decode="utf-8")
+        return output
+
     def get_user(self, user_name_or_uuid: str) -> OPUser:
         user_json = super()._get_user(user_name_or_uuid)
         user = OPUser(user_json)

--- a/pyonepassword/pyonepassword.py
+++ b/pyonepassword/pyonepassword.py
@@ -76,6 +76,8 @@ class _OPPrivate(_OPCommandInterface):
 
     def get_totp(self, item_name_or_uuid, vault=None):
         output = super()._get_totp(item_name_or_uuid, vault=vault, decode="utf-8")
+        # strip newline
+        output = output.rstrip()
         return output
 
     def get_user(self, user_name_or_uuid: str) -> OPUser:


### PR DESCRIPTION
Since this command just produces console output instead of a json object, I did not use any factory methods to massage the output, it just returns it raw. There is not currently a "raw" type, so this probably should be addressed.