### PR TITLE
#64 missing packages in latest release

### DIFF
--- a/docker_testing/clean.sh
+++ b/docker_testing/clean.sh
@@ -1,3 +1,4 @@
 #!/bin/sh
 
 docker image rm docker_py39 docker_py38 docker_py310 docker_py311 docker_mypy
+rm -rf .tox-docker

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ with open(os.path.join(proj_path, "README.md"), "r") as fp:
     long_description = fp.read()
 
 
-packages = find_packages(where=".", include=["pyonepassword"])
+packages = find_packages(where=".", include=["pyonepassword.*"])
 
 setup(
     name=about["__title__"],

--- a/tox.ini
+++ b/tox.ini
@@ -27,6 +27,7 @@ commands =
 [pytest]
 env_files =
     .test.env
+addopts = "--import-mode=append"
 
 [coverage:run]
 omit =


### PR DESCRIPTION
- fix `find_packates()` in `setup.py` not finding all packages (#64)
- fix `tox` config such that package installed in tox virtualenv are tested rather than what's in local project directory
